### PR TITLE
Park name fix

### DIFF
--- a/app/helpers/park_name_converter.rb
+++ b/app/helpers/park_name_converter.rb
@@ -1,6 +1,6 @@
 module ParkNameConverter
-  def convert_to_park_code(park_name)
-    park_codes = {
+def park_codes
+    {
       'ACADIA' => 'ACAD',
       'ARCHES' => 'ARCH',
       'BADLANDS' => 'BADL',
@@ -60,8 +60,15 @@ module ParkNameConverter
       'YELLOWSTONE' => 'YELL',
       'YOSEMITE' => 'YOSE',
       'ZION' => 'ZION'
-      }
+    }
+  end 
     
+  def convert_to_park_code(park_name)
     park_codes[park_name]
+  end
+
+  def convert_to_park_name(park_code)
+    new_hash = park_codes.invert
+    new_hash[park_code]
   end
 end

--- a/app/poros/campsite.rb
+++ b/app/poros/campsite.rb
@@ -1,4 +1,6 @@
 class Campsite 
+  include ParkNameConverter
+
   attr_reader :name,
               :id,
               :lat,
@@ -19,7 +21,8 @@ class Campsite
               :ice_available,
               :firewood_available,
               :wheelchair_access,
-              :weather_info
+              :weather_info,
+              :park_code
 
   def initialize(camp_data)
     @name = camp_data[:name]
@@ -43,6 +46,10 @@ class Campsite
     @firewood_available = camp_data[:amenities][:firewoodForSale]
     @wheelchair_access = camp_data[:accessibility][:wheelchairAccess]
     @weather_info = camp_data[:weatherOverview]
-    # @activities =
+    @park_code = camp_data[:parkCode]
+  end
+
+  def park_name
+    convert_to_park_name(park_code.upcase)
   end
 end

--- a/app/poros/campsite_search.rb
+++ b/app/poros/campsite_search.rb
@@ -1,5 +1,7 @@
 class CampsiteSearch
-  attr_reader :name, :id, :description, :images, :park_code, :cost
+  include ParkNameConverter
+
+  attr_reader :name, :id, :description, :images, :park_code, :state, :cost
 
   def initialize(data)
     @name = data[:name]
@@ -7,6 +9,19 @@ class CampsiteSearch
     @description = data[:description]
     @images = data[:images]
     @park_code = data[:parkCode]
+    @state = data[:addresses]
     @cost = data[:fees]
+  end
+
+  def state_code 
+    if state[0].nil?
+      nil
+    else
+      state[0][:stateCode]
+    end
+  end
+
+  def park_name
+    convert_to_park_name(park_code.upcase)
   end
 end

--- a/app/serializers/campsite_search_serializer.rb
+++ b/app/serializers/campsite_search_serializer.rb
@@ -1,5 +1,5 @@
 class CampsiteSearchSerializer
   include JSONAPI::Serializer
 
-  attributes :name, :description, :images, :park_code, :cost
+  attributes :name, :description, :images, :park_name, :state_code, :cost
 end

--- a/app/serializers/campsite_serializer.rb
+++ b/app/serializers/campsite_serializer.rb
@@ -1,5 +1,5 @@
 class CampsiteSerializer
   include JSONAPI::Serializer
 
-  attributes :name, :lat, :long, :booking_link, :description, :images, :cost, :number_of_reservation_sites, :reservation_info, :toilets, :showers, :cell_coverage, :laundry, :dump_station, :camp_store, :potable_water, :ice_available, :firewood_available, :wheelchair_access, :weather_info
+  attributes :name, :lat, :long, :booking_link, :description, :images, :cost, :number_of_reservation_sites, :reservation_info, :toilets, :showers, :cell_coverage, :laundry, :dump_station, :camp_store, :potable_water, :ice_available, :firewood_available, :wheelchair_access, :weather_info, :park_name
 end

--- a/spec/poro/campsite_search_spec.rb
+++ b/spec/poro/campsite_search_spec.rb
@@ -15,5 +15,8 @@ RSpec.describe CampsiteSearch do
     expect(campsites[0].description).to eq("Aspenglen Campground is reservation only. Visit Recreation.gov. Aspenglen opens for the 2023 season on May 26. Timed Entry Permits are included with your camping reservation. For Aspenglen Campers, your reservation includes access to Bear Lake Road. Campers will be able to initially enter the park beginning at 1 p.m. on the first day of your camping reservation. If you plan to enter the park earlier in the day, you will have to enter the park outside of the times when Timed Entry Permits are in effect.")
     expect(campsites[0].images).to be_an(Array)
     expect(campsites[0].images[0][:url]).to eq("https://www.nps.gov/common/uploads/structured_data/3FAA6E89-1DD8-B71B-0B170E56BD4ED00D.jpg")
+    expect(campsites[0].state_code).to eq("CO")
+    expect(campsites[2].state_code).to eq(nil)
+    expect(campsites[0].park_name).to eq("ROCKY MOUNTAIN")
   end
 end

--- a/spec/poro/campsite_spec.rb
+++ b/spec/poro/campsite_spec.rb
@@ -33,5 +33,7 @@ RSpec.describe Campsite do
     expect(campsite.firewood_available).to eq("Yes - seasonal")
     expect(campsite.wheelchair_access).to eq("Two ADA sites are offered for those customers with a disability or otherwise limited mobility who would benefit from the accessibility design features.")
     expect(campsite.weather_info).to eq("Average High and Low Temperatures (Fahrenheit): May: 62 / 34 June: 73 / 41 July: 78 / 46 August: 77 / 45 September: 70 / 38")
+    expect(campsite.park_code).to eq("romo")
+    expect(campsite.park_name).to eq("ROCKY MOUNTAIN")
   end
 end

--- a/spec/requests/api/v1/campsite_request_spec.rb
+++ b/spec/requests/api/v1/campsite_request_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'Campsite API' do
       expect(campsite_details[:data][:attributes]).to have_key(:firewood_available)
       expect(campsite_details[:data][:attributes]).to have_key(:wheelchair_access)
       expect(campsite_details[:data][:attributes]).to have_key(:weather_info)
+      expect(campsite_details[:data][:attributes]).to have_key(:park_name)
     end
   end
 end

--- a/spec/requests/api/v1/campsites_search_request.rb
+++ b/spec/requests/api/v1/campsites_search_request.rb
@@ -35,6 +35,8 @@ RSpec.describe 'CampsitesSearch API' do
         expect(campsite[:attributes]).to have_key(:images)
         expect(campsite[:attributes][:images]).to be_an(Array)
         expect(campsite[:attributes]).to have_key(:cost)
+        expect(campsite[:attributes]).to have_key(:park_name)
+        expect(campsite[:attributes]).to have_key(:state_code)
       end
     end
   end
@@ -63,7 +65,8 @@ RSpec.describe 'CampsitesSearch API' do
         expect(campsite[:attributes]).to have_key(:images)
         expect(campsite[:attributes][:images]).to be_an(Array)
         expect(campsite[:attributes]).to have_key(:cost)
-
+        expect(campsite[:attributes]).to have_key(:park_name)
+        expect(campsite[:attributes]).to have_key(:state_code)
       end
     end
   end
@@ -92,7 +95,8 @@ RSpec.describe 'CampsitesSearch API' do
         expect(campsite[:attributes]).to have_key(:images)
         expect(campsite[:attributes][:images]).to be_an(Array)
         expect(campsite[:attributes]).to have_key(:cost)
-
+        expect(campsite[:attributes]).to have_key(:park_name)
+        expect(campsite[:attributes]).to have_key(:state_code)
       end
     end
   end


### PR DESCRIPTION
## What does this merge do? Check all that apply.
- [ ] Adds a new feature
- [x] Improves an existing feature
- [ ] Fixes a bug
- [ ] Cleans up (logs, tests, etc.)

## How has this been tested?
Rspec added testing to campsite search and campsite poros
Rspec added testing to campsite search and campsite details request endpoints

## Description:
Briefly, but clearly describe what you did, and explain any new code.
Updated the park name converter module to include a method to return the park name
Updated the campsite search poro to have both the state code and park name
Updated the campsite details poro to have the park name
Updated campsite search and campsite serializers to have state code and park name 

## Issues:
Are there any concerns, issues, or bugs in this branch? If so describe them.

## Where to find Changes:
Files:
Methods:
Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have used tests to prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my change
